### PR TITLE
Dynamic IR send repeat and ESP32 GPIO output mask

### DIFF
--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -50,12 +50,10 @@ IRsend::IRsend(uint16_t IRsendPin, bool inverted, bool use_modulation)
 /// @param[in] use_modulation Do we do frequency modulation during transmission?
 ///  i.e. If not, assume a 100% duty cycle. Ignore attempts to change the
 ///  duty cycle etc.
-/// @param[in] irPinIsMask GPIO output pin mask to use when sending an IR
+/// @param[in] ir_pin_mask GPIO output pin mask to use when sending an IR
 ///  command.
-IRsend::IRsend(bool use_modulation, uint32_t irPinIsMask) : IRpin(irPinIsMask),
-    _irPinIsMask(true) {
-  outputOn = HIGH;
-  outputOff = LOW;
+IRsend::IRsend(bool use_modulation, uint32_t ir_pin_mask) : IRpin(ir_pin_mask),
+    periodOffset(kPeriodOffset), _irPinIsMask(true) {
   modulation = use_modulation;
   if (modulation)
     _dutycycle = kDutyDefault;
@@ -70,6 +68,9 @@ IRsend::IRsend(bool use_modulation, uint32_t irPinIsMask) : IRpin(irPinIsMask),
 uint32_t IRsend::setPinMask(uint32_t ir_pin_mask) {
   if (!_irPinIsMask) {
     return 0;
+  }
+  if (IRpin == ir_pin_mask) {
+    return ir_pin_mask;
   }
   // Make sure the old outputs are turned off
   ledOff();

--- a/src/IRsend.cpp
+++ b/src/IRsend.cpp
@@ -359,7 +359,8 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
   IRtimer usecs = IRtimer();
 
   // We always send a message, even for repeat=0, hence '<= repeat'.
-  for (uint16_t r = 0; r <= repeat; r++) {
+  for (uint16_t r = 0; r <= repeat
+       || (repeat > 0 && _repeatCB && _repeatCB()); r++) {
     usecs.reset();
 
     // Header
@@ -416,7 +417,8 @@ void IRsend::sendGeneric(const uint16_t headermark, const uint32_t headerspace,
   // Setup
   enableIROut(frequency, dutycycle);
   // We always send a message, even for repeat=0, hence '<= repeat'.
-  for (uint16_t r = 0; r <= repeat; r++) {
+  for (uint16_t r = 0; r <= repeat
+       || (repeat > 0 && _repeatCB && _repeatCB()); r++) {
     // Header
     if (headermark) mark(headermark);
     if (headerspace) space(headerspace);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -244,7 +244,7 @@ class IRsend {
                   bool use_modulation = true);
 #if defined(ESP32)
   explicit IRsend(bool use_modulation, uint32_t ir_pin_mask);
-  uint32_t setPinMask(uint32_t irPinIsMask);
+  uint32_t setPinMask(uint32_t ir_pin_mask);
 #endif
   void begin();
   void enableIROut(uint32_t freq, uint8_t duty = kDutyDefault);

--- a/src/IRsend.h
+++ b/src/IRsend.h
@@ -242,6 +242,10 @@ class IRsend {
  public:
   explicit IRsend(uint16_t IRsendPin, bool inverted = false,
                   bool use_modulation = true);
+#if defined(ESP32)
+  explicit IRsend(bool use_modulation, uint32_t ir_pin_mask);
+  uint32_t setPinMask(uint32_t irPinIsMask);
+#endif
   void begin();
   void enableIROut(uint32_t freq, uint8_t duty = kDutyDefault);
   VIRTUAL void _delayMicroseconds(uint32_t usec);
@@ -923,7 +927,7 @@ class IRsend {
 #endif  // UNIT_TEST
   uint16_t onTimePeriod;
   uint16_t offTimePeriod;
-  uint16_t IRpin;
+  uint32_t IRpin;
   int8_t periodOffset;
   uint8_t _dutycycle;
   bool modulation;
@@ -934,6 +938,10 @@ class IRsend {
 #endif  // SEND_SONY
 
   RepeatCallbackFunction _repeatCB = nullptr;
+#if defined(ESP32)
+  // Use a pinmask for IR output instead a single pin.
+  bool _irPinIsMask;
+#endif
 };
 
 #endif  // IRSEND_H_

--- a/src/ir_GlobalCache.cpp
+++ b/src/ir_GlobalCache.cpp
@@ -39,7 +39,8 @@ void IRsend::sendGC(uint16_t buf[], uint16_t len) {
   uint8_t emits =
       std::min(buf[kGlobalCacheRptIndex], (uint16_t)kGlobalCacheMaxRepeat);
   // Repeat
-  for (uint8_t repeat = 0; repeat < emits; repeat++) {
+  for (uint8_t repeat = 0; repeat < emits
+       || (emits > 1 && _repeatCB && _repeatCB()); repeat++) {
     // First time through, start at the beginning (kGlobalCacheStartIndex),
     // otherwise for repeats, we start a specified offset from that.
     uint16_t offset = kGlobalCacheStartIndex;

--- a/src/ir_JVC.cpp
+++ b/src/ir_JVC.cpp
@@ -54,7 +54,8 @@ void IRsend::sendJVC(uint64_t data, uint16_t nbits, uint16_t repeat) {
   space(kJvcHdrSpace);
 
   // We always send the data & footer at least once, hence '<= repeat'.
-  for (uint16_t i = 0; i <= repeat; i++) {
+  for (uint16_t i = 0; i <= repeat
+       || (repeat > 0 && _repeatCB && _repeatCB()); i++) {
     sendGeneric(0, 0,  // No Header
                 kJvcBitMark, kJvcOneSpace, kJvcBitMark, kJvcZeroSpace,
                 kJvcBitMark, kJvcMinGap, data, nbits, 38, true,

--- a/src/ir_Pronto.cpp
+++ b/src/ir_Pronto.cpp
@@ -97,7 +97,8 @@ bool IRsend::sendPronto(uint16_t data[], uint16_t len, uint16_t repeat) {
     if (seq_2_len + seq_2_start > len) return false;
 
     // Send the contents of the 2nd sequence.
-    for (uint16_t r = 0; r < repeat; r++)
+    for (uint16_t r = 0; r < repeat
+         || (repeat > 1 && _repeatCB && _repeatCB()); r++)
       for (uint16_t i = seq_2_start; i < seq_2_start + seq_2_len; i += 2) {
         mark((data[i] * periodic_time_x10) / 10);
         space((data[i + 1] * periodic_time_x10) / 10);

--- a/src/ir_RC5_RC6.cpp
+++ b/src/ir_RC5_RC6.cpp
@@ -73,7 +73,8 @@ void IRsend::sendRC5(const uint64_t data, uint16_t nbits,
   }
 
   IRtimer usecTimer = IRtimer();
-  for (uint16_t i = 0; i <= repeat; i++) {
+  for (uint16_t i = 0; i <= repeat
+       || (repeat > 0 && _repeatCB && _repeatCB()); i++) {
     usecTimer.reset();
 
     // Header
@@ -193,7 +194,8 @@ void IRsend::sendRC6(const uint64_t data, const uint16_t nbits,
   if (nbits > sizeof(data) * 8) return;
   // Set 36kHz IR carrier frequency & a 1/3 (33%) duty cycle.
   enableIROut(36, 33);
-  for (uint16_t r = 0; r <= repeat; r++) {
+  for (uint16_t r = 0; r <= repeat
+       || (repeat > 0 && _repeatCB && _repeatCB()); r++) {
     // Header
     mark(kRc6HdrMark);
     space(kRc6HdrSpace);

--- a/src/ir_Sharp.cpp
+++ b/src/ir_Sharp.cpp
@@ -65,7 +65,8 @@ using irutils::minsToString;
 void IRsend::sendSharpRaw(const uint64_t data, const uint16_t nbits,
                           const uint16_t repeat) {
   uint64_t tempdata = data;
-  for (uint16_t i = 0; i <= repeat; i++) {
+  for (uint16_t i = 0; i <= repeat
+       || (repeat > 0 && _repeatCB && _repeatCB()); i++) {
     // Protocol demands that the data be sent twice; once normally,
     // then with all but the address bits inverted.
     // Note: Previously this used to be performed 3 times (normal, inverted,


### PR DESCRIPTION
This PR adds two new functionalities for the UCD2 dock: continuous IR repeat and parallel IR output.

## Continuous IR repeat
Certain IR commands require native IR repeat functionality for better user experience.
The most prominent use case is volume control:
- Certain devices (mostly amplifiers and AVRs) have a progressive volume control.
  Volume is increased / decreased slowly, then getting progressivly faster the longer the volume button on the remote is pressed.
- "Run-away" avoidance: users expect that volume increase _immediately_ stops when they release the button.
  The volume may not continue increasing for a while after releasing the button!

The solution to continue repeating the fixed repeat count in `IRsend` is with a callback function.

The initial repeat count is still taken from the IR send function.
The callback is called during the repeat sequence in the IR specific protocol sending function to check if the repeat count needs to be extended.
Note: the initial repeat value cannot be shortened, only prolonged!

The specific logic on how the repeat count is prolonged is up to the client. It can either count the number of callbacks to act on specific counts, or set a timeout when it signals to no longer repeat the IR code.

## Parallel IR sending
The UCD2 dock has 4 controllable IR outputs. When using multiple outputs at the same time, we used an IRQ hack with an unused GPIO, which triggered redirecting the GPIO state to the real outputs.

To avoid using an IRQ, `IRsend` now directly supports a ESP32 GPIO output mask.
This allows parallel sending the same IR code on multiple outputs.
The output mask can also be changed between sending to avoid creating a new `IRsend` object.