### PR TITLE
Fix IRsend microsecond delay function on ESP IDF

### DIFF
--- a/src/hal/esp32-hal-misc.c
+++ b/src/hal/esp32-hal-misc.c
@@ -79,7 +79,7 @@ unsigned long ARDUINO_ISR_ATTR millis() {
 }
 
 void delay(uint32_t ms) {
-    vTaskDelay(ms / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(ms));
 }
 
 void ARDUINO_ISR_ATTR delayMicroseconds(uint32_t us) {

--- a/src/hal/esp32-hal.h
+++ b/src/hal/esp32-hal.h
@@ -86,8 +86,19 @@ void yield(void);
 
 unsigned long micros();
 unsigned long millis();
-void          delay(uint32_t);
-void          delayMicroseconds(uint32_t us);
+
+/// @brief Delay for given milliseconds.
+///
+/// Attention: uses vTaskDelay and the actual time that the task remains
+/// blocked depends on the tick rate!
+/// With the default tick rate of 100Hz, the resolution is 10ms.
+/// Any time below that value might not delay the task at all.
+/// @param ms milliseconds to wait.
+void delay(uint32_t ms);
+
+/// @brief **Busy wait** for the given microseconds.
+/// @param us microseconds to wait.
+void delayMicroseconds(uint32_t us);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Delay functions work differently on native ESP IDF than with the Arduino framework. Keep track of the real delay when the task gets suspended if the delay is > 16ms and vTaskDelay is called.

Discovered in https://github.com/unfoldedcircle/ucd3-firmware/issues/33